### PR TITLE
fix: use get_user_model

### DIFF
--- a/.salt/300_app.sls
+++ b/.salt/300_app.sls
@@ -155,8 +155,8 @@ user-{{cfg.name}}-{{admin}}:
                     import django;django.setup()
                 except Exception:
                     pass
-                from {{ds.USER_MODULE}} import {{ds.USER_CLASS}} as User
-                User.objects.filter(username='{{admin}}').all()[0]
+                from django.contrib.auth import get_user_model
+                get_user_model().objects.filter(username='{{admin}}').all()[0]
                 if os.path.isfile("{{f}}"):
                     os.unlink("{{f}}")
     - mode: 700
@@ -192,8 +192,8 @@ superuser-{{cfg.name}}-{{admin}}:
                     import django;django.setup()
                 except Exception:
                     pass
-                from {{ds.USER_MODULE}} import {{ds.USER_CLASS}} as User
-                user=User.objects.filter(username='{{admin}}').all()[0]
+                from django.contrib.auth import get_user_model
+                user = get_user_model().objects.filter(username='{{admin}}').all()[0]
                 user.set_password('{{udata.password}}')
                 user.email = '{{udata.mail}}'
                 user.save()

--- a/.salt/PILLAR.sample
+++ b/.salt/PILLAR.sample
@@ -153,8 +153,6 @@ makina-projects.projectname:
       #  default:
       #    BACKEND: 'django.core.cache.backends.memcached.MemcachedCache'
       #    LOCATION: '127.0.0.1:11211'
-      USER_MODULE: django.contrib.auth.models
-      USER_CLASS: User
       SECRET_KEY: "{{salt['mc_utils.generate_stored_password'](
                              'corpus-django_web_secret_key', 64)}}"
       LOGGING:


### PR DESCRIPTION
Une raison particulière d'utiliser des variables pour determiner le modèle User ?

Il est déjà configuré dans les settings de Django.